### PR TITLE
Add the gets command metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(e.commandArgs, prometheus.GaugeValue, 1, s["commandargs"])
 
 	// Commands
-	for _, op := range []string{"add", "append", "cas", "decr", "flushall", "flushre", "get", "incr", "metaget", "prepend", "replace", "touch", "set", "delete", "lease_get", "lease_set"} {
+	for _, op := range []string{"add", "append", "cas", "decr", "flushall", "flushre", "get", "gets", "incr", "metaget", "prepend", "replace", "touch", "set", "delete", "lease_get", "lease_set"} {
 		key := "cmd_" + op
 		ch <- prometheus.MustNewConstMetric(
 			e.commands, prometheus.GaugeValue, parse(s, key), op)


### PR DESCRIPTION
The 'gets' command has its own set of metrics recorded by mcrouter.
This is an example from one of the mcrouters that we ran:

STAT cmd_gets_out_all 2636.858333333333
STAT cmd_gets 2636.7625000000003
STAT cmd_gets_out 2636.925
STAT cmd_gets_count 41267549924