### PR TITLE
Add the tko reply back to mcrouter_result_all

### DIFF
--- a/main.go
+++ b/main.go
@@ -515,7 +515,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	// Result Reply
 	// See ProxyRequestLogger.cpp
-	for _, op := range []string{"busy", "connect_error", "connect_timeout", "data_timeout", "error", "local_error"} {
+	for _, op := range []string{"busy", "connect_error", "connect_timeout", "data_timeout", "error", "local_error", "tko"} {
 		key := "result_" + op
 		ch <- prometheus.MustNewConstMetric(
 			e.results, prometheus.GaugeValue, parse(s, key), op)


### PR DESCRIPTION
In the previous commit a generic metric for TKOs (no distinction
between hard and soft) was removed, re-adding it.

This change allows the exporter to re-generate metrics like:

mcrouter_result_all{reply="tko"} 42
mcrouter_result_all_count{reply="tko"} 42
mcrouter_result_count{reply="tko"} 42
mcrouter_results{reply="tko"} 42