### PR TITLE
Move to Distroless + Github Actions support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - checkout
       - run: go get github.com/smartystreets/goconvey
-      - run: go get -v ./...
-      - run: go test -v ./...
+      - run: make test
 
 workflows:
   test_and_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
           REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
           docker build -t docker.pkg.github.com/${REPOSITORY}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
 
-      - name: Log in to registry
-        run: echo ${{ secrets.DOCKER_GITHUB_PASSWORD }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
+      - name: Login to GitHub Package Registry
+        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push'
 
       - name: Push image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
+        run: |
+          REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
+          docker build -t docker.pkg.github.com/${REPOSITORY}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
 
       - name: Log in to registry
         run: echo ${{ secrets.DOCKER_GITHUB_PASSWORD }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
         if: github.event_name == 'push'
 
       - name: Push image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}
+        run: |
+          REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
+          docker push docker.pkg.github.com/${REPOSITORY}
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - distroless # TODO: Remove me
-  pull_request:
 
 jobs:
   build:
@@ -78,15 +77,17 @@ jobs:
         run: |
           REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
           TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
+
           docker build -t docker.pkg.github.com/${REPOSITORY}:${TAG} .
+        if: github.event_name == 'push'
 
       - name: Login to GitHub Package Registry
         run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push'
 
-      - name: Push image
+      - name: Push images
         run: |
           REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
-          TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
-          docker push docker.pkg.github.com/${REPOSITORY}:${TAG}
+
+          docker push docker.pkg.github.com/${REPOSITORY}
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Build image
         run: |
           REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
-          docker build -t docker.pkg.github.com/${REPOSITORY}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
+          TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
+          docker build -t docker.pkg.github.com/${REPOSITORY}:${TAG} .
 
       - name: Login to GitHub Package Registry
         run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
@@ -86,5 +87,6 @@ jobs:
       - name: Push image
         run: |
           REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
-          docker push docker.pkg.github.com/${REPOSITORY}
+          TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
+          docker push docker.pkg.github.com/${REPOSITORY}:${TAG}
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - distroless # TODO: Remove me
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Build image
         run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
 
-     - name: Log in to registry
-       run: echo ${{ secrets.DOCKER_GITHUB_PASSWORD }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
-       if: github.event_name == 'push'
+      - name: Log in to registry
+        run: echo ${{ secrets.DOCKER_GITHUB_PASSWORD }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
+        if: github.event_name == 'push'
 
-     - name: Push image
-       run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}
-       if: github.event_name == 'push'
+      - name: Push image
+        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}
+        if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build image
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
+          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')/
           TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
           docker build -t docker.pkg.github.com/${REPOSITORY}:${TAG} .
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Push image
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]')
+          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')/
           TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
           docker push docker.pkg.github.com/${REPOSITORY}:${TAG}
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build image
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')/
+          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
           TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
           docker build -t docker.pkg.github.com/${REPOSITORY}:${TAG} .
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Push image
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')/
+          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
           TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
           docker push docker.pkg.github.com/${REPOSITORY}:${TAG}
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - distroless # TODO: Remove me
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      VERBOSE: 1
+      GOFLAGS: -mod=readonly
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: make build
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      VERBOSE: 1
+      GOFLAGS: -mod=readonly
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Lint
+        run: make lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      VERBOSE: 1
+      GOFLAGS: -mod=readonly
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Test
+        run: make test
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}:${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7} .
+
+     - name: Log in to registry
+       run: echo ${{ secrets.DOCKER_GITHUB_PASSWORD }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
+       if: github.event_name == 'push'
+
+     - name: Push image
+       run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{ github.event.repository.name }}
+       if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Build
         run: make build
 
+  # TODO: Replace with Action
+  # https://github.com/golangci/golangci-lint-action
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 *.prof
 
 mcrouter_exporter
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+run:
+    skip-files:
+        - ".*_test\\.go$"
+
+linters-settings:
+    golint:
+        min-confidence: 0.1
+
+linters:
+    # enable-all: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.14.4 as builder
 WORKDIR /workspace
 COPY . /workspace
-RUN make docker
+RUN make build-docker
 
 # Use distroless as final image
 FROM gcr.io/distroless/base-debian10

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.14.4 as builder
 WORKDIR /workspace
 COPY . /workspace
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o mcrouter_exporter main.go
+RUN make docker
 
 # Use distroless as final image
 FROM gcr.io/distroless/base-debian10

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ vet:
 	@go vet ${PKG_LIST}
 
 test: fmt vet
-	go test
+	go test -mod=vendor
 
 build:
-	go build -i -v -o ${OUT} -ldflags=$(FLAGS)
+	go build -mod=vendor -i -v -o ${OUT} -ldflags=$(FLAGS)
 
 docker:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -i -a -o ${OUT} -ldflags=$(FLAGS)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -i -a -o ${OUT} -ldflags=$(FLAGS)
 
 clean:
 	-@rm -f ${OUT}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ test: fmt vet
 build:
 	go build -i -v -o ${OUT} -ldflags=$(FLAGS)
 
+docker:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -i -a -o ${OUT} -ldflags=$(FLAGS)
+
 clean:
 	-@rm -f ${OUT}
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ FLAGS := "-X github.com/prometheus/common/version.Version=${VERSION} \
 	-X github.com/prometheus/common/version.Revision=${REVISION} \
 	-X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}"
 
-all: build
-
+all: fmt lint build
 
 bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
@@ -32,23 +31,26 @@ lint: bin/golangci-lint ## Run linter
 fix: bin/golangci-lint ## Fix lint violations
 	bin/golangci-lint run --fix
 
-
+.PHONY: fmt
 fmt:
 	@go fmt
 
+.PHONY: vet
 vet:
 	@go vet ${PKG_LIST}
 
+.PHONY: test
 test: fmt vet
 	go test -mod=vendor
 
+.PHONY: build
 build:
 	go build -mod=vendor -i -v -o ${OUT} -ldflags=$(FLAGS)
 
+.PHONY: build-docker
 build-docker:
 	CGO_ENABLED=0 go build -mod=vendor -i -a -o ${OUT} -ldflags=$(FLAGS)
 
+.PHONY: clean
 clean:
 	-@rm -f ${OUT}
-
-.PHONY: all setup fmt test build clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 PKG := github.com/dev25/mcrouter_exporter
 OUT := mcrouter_exporter
 
+GOLANGCI_VERSION ?= 1.27.0
+
 # Build info
 REVISION := $(shell git describe --always --long --dirty)
 VERSION := $(shell git tag --points-at HEAD)
@@ -13,6 +15,23 @@ FLAGS := "-X github.com/prometheus/common/version.Version=${VERSION} \
 	-X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}"
 
 all: build
+
+
+bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
+	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
+bin/golangci-lint-${GOLANGCI_VERSION}:
+	@mkdir -p bin
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
+	@mv bin/golangci-lint $@
+
+.PHONY: lint
+lint: bin/golangci-lint ## Run linter
+	bin/golangci-lint run
+
+.PHONY: fix
+fix: bin/golangci-lint ## Fix lint violations
+	bin/golangci-lint run --fix
+
 
 fmt:
 	@go fmt

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ test: fmt vet
 build:
 	go build -mod=vendor -i -v -o ${OUT} -ldflags=$(FLAGS)
 
-docker:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -i -a -o ${OUT} -ldflags=$(FLAGS)
+build-docker:
+	CGO_ENABLED=0 go build -mod=vendor -i -a -o ${OUT} -ldflags=$(FLAGS)
 
 clean:
 	-@rm -f ${OUT}

--- a/main.go
+++ b/main.go
@@ -760,6 +760,7 @@ func main() {
 	prometheus.MustRegister(NewExporter(*address, *timeout, *serverMetrics))
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		//nolint:errcheck
 		w.Write([]byte(`<html>
              <head><title>Mcrouter Exporter</title></head>
              <body>


### PR DESCRIPTION
Changes:
- Closes #17 for moving to distroless
- Fix flaky tests by using `net.Pipe()` for creating server/client conn
- Add Github Actions support for publishing images
- Add golangci-lint with a minimal config for now.