### PR TITLE
Add client connections metric for v39+

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ type Exporter struct {
 	resultShadow                  *prometheus.Desc
 	resultAll                     *prometheus.Desc
 	resultAllCount                *prometheus.Desc
-	numClients                    *prometheus.Desc
+	clients                       *prometheus.Desc
 	numClientConnections          *prometheus.Desc
 	servers                       *prometheus.Desc
 	cpuSeconds                    *prometheus.Desc
@@ -205,8 +205,8 @@ func NewExporter(server string, timeout time.Duration, server_stats bool, logger
 			nil,
 			nil,
 		),
-		numClients: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "num_clients"),
+		clients: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "clients"),
 			"Number of connected clients (prior to version 39).",
 			nil,
 			nil,
@@ -424,7 +424,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.resultShadow
 	ch <- e.resultAll
 	ch <- e.resultAllCount
-	ch <- e.numClients
+	ch <- e.clients
 	ch <- e.numClientConnections
 	ch <- e.servers
 	ch <- e.cpuSeconds
@@ -541,7 +541,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	// Clients
 	ch <- prometheus.MustNewConstMetric(
-		e.numClients, prometheus.CounterValue, e.parse(s, "num_clients"))
+		e.clients, prometheus.CounterValue, e.parse(s, "num_clients"))
 	ch <- prometheus.MustNewConstMetric(
 		e.numClientConnections, prometheus.GaugeValue, e.parse(s, "num_client_connections"))
 

--- a/main.go
+++ b/main.go
@@ -58,7 +58,8 @@ type Exporter struct {
 	resultShadow                  *prometheus.Desc
 	resultAll                     *prometheus.Desc
 	resultAllCount                *prometheus.Desc
-	clients                       *prometheus.Desc
+	numClients                    *prometheus.Desc
+	numClientConnections          *prometheus.Desc
 	servers                       *prometheus.Desc
 	cpuSeconds                    *prometheus.Desc
 	residentMemory                *prometheus.Desc
@@ -204,9 +205,15 @@ func NewExporter(server string, timeout time.Duration, server_stats bool, logger
 			nil,
 			nil,
 		),
-		clients: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "clients"),
-			"Number of connected clients.",
+		numClients: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "num_clients"),
+			"Number of connected clients (prior to version 39).",
+			nil,
+			nil,
+		),
+		numClientConnections: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "num_client_connections"),
+			"Number of connected clients (version 39 and after).",
 			nil,
 			nil,
 		),
@@ -417,7 +424,8 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.resultShadow
 	ch <- e.resultAll
 	ch <- e.resultAllCount
-	ch <- e.clients
+	ch <- e.numClients
+	ch <- e.numClientConnections
 	ch <- e.servers
 	ch <- e.cpuSeconds
 	ch <- e.residentMemory
@@ -533,7 +541,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	// Clients
 	ch <- prometheus.MustNewConstMetric(
-		e.clients, prometheus.CounterValue, e.parse(s, "num_clients"))
+		e.numClients, prometheus.CounterValue, e.parse(s, "num_clients"))
+	ch <- prometheus.MustNewConstMetric(
+		e.numClientConnections, prometheus.GaugeValue, e.parse(s, "num_client_connections"))
 
 	// Servers
 	for _, op := range []string{"closed", "down", "new", "up"} {


### PR DESCRIPTION
The metric name for the number of client connections changed from `num_clients` to `num_client_connections` in version 39.

This adds a new gauge for the updated metric name, without changing the existing metric (for backwards compatibility). Although the existing `num_clients` metric is registered a counter, this metric is actually exported as a gauge by mcrouter; thus, I made this new metric a gauge.