### PR TITLE
Add dependabot to the repository, pin base image version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /workspace
 RUN make build-docker
 
 # Use distroless as final image
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base-debian11@sha256:e5853c0285c4c07ab5724d0b582c9b168f6c8dfa330627d22f814d98d77c5b85
 WORKDIR /
 COPY --from=builder /workspace/mcrouter_exporter .
 ENTRYPOINT ["/mcrouter_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /workspace
 RUN make build-docker
 
 # Use distroless as final image
-FROM gcr.io/distroless/base-debian11@sha256:e5853c0285c4c07ab5724d0b582c9b168f6c8dfa330627d22f814d98d77c5b85
+FROM gcr.io/distroless/base-debian11@sha256:7b9dc0fa2731bfddc1a94c84994bd2ef87b2d89721596331fc63c5403b8c3f64
 WORKDIR /
 COPY --from=builder /workspace/mcrouter_exporter .
 ENTRYPOINT ["/mcrouter_exporter"]


### PR DESCRIPTION
This pull request aim to help with easing the burden of maintaining the repository by automating updates to the base image. 

Current base image was build long time ago and vulnerability scanner returns quite a few high and critical problems with it:
```
quay.io/dev25/mcrouter_exporter:master-b09504e51f041bf9154bb08d5feeb3f0a157344a@sha256:a6e22b513e37e1a36503c258883295a1d2c82770635e4571de2429ae506b8ba4 (debian 11.2)

Total: 26 (UNKNOWN: 0, LOW: 12, MEDIUM: 4, HIGH: 3, CRITICAL: 7)
```

If the image will be rebuild with current upstream image the exporter will be in much better shape: 
```
gcr.io/distroless/base-debian11 (debian 11.5)

Total: 13 (UNKNOWN: 0, LOW: 11, MEDIUM: 2, HIGH: 0, CRITICAL: 0)
```

I hope that pinning the image + automating base image update, will help with easing up the maintenance burden of this repository. 