### PR TITLE
Build multi-arch docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,22 +51,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build image
-        run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
-          TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-          docker build -t ghcr.io/${REPOSITORY}:${TAG} .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push'
 
-      - name: Login to GitHub Package Registry
-        run: docker login ghcr.io -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push'
-
-      - name: Push images
+      - name: Setup tag
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
-          TAG=${GITHUB_REF#"refs/heads/"}-${GITHUB_SHA:0:7}
+          echo "repo_downcase=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "image_tag=${branch}-${GITHUB_SHA:0:7}" >>${GITHUB_ENV}
 
-          docker push ghcr.io/${REPOSITORY}:${TAG}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.repo_downcase }}:${{ env.image_tag }}
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,22 +51,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build image
-        run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
-          TAG=${GITHUB_REF#"refs/tags/"}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-          docker build -t ghcr.io/${REPOSITORY}:${TAG} .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push'
 
-      - name: Login to GitHub Package Registry
-        run: docker login ghcr.io -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push'
-
-      - name: Push images
+      - name: Setup tag
         run: |
-          REPOSITORY=$(echo $GITHUB_REPOSITORY/${{ github.event.repository.name }} | tr '[A-Z]' '[a-z]')
-          TAG=${GITHUB_REF#"refs/tags/"}
+          echo "repo_downcase=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo "image_tag=${GITHUB_REF#refs/tags/}" >>${GITHUB_ENV}
 
-          docker push ghcr.io/${REPOSITORY}:${TAG}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.repo_downcase }}:${{ env.image_tag }}
         if: github.event_name == 'push'


### PR DESCRIPTION
Hey 👋 I wonder if you would accept this pull request to build the docker image on both `linux/arm64` and `linux/amd64`? I've tested these workflows on [my fork](https://github.com/DazWorrall/mcrouter_exporter/pkgs/container/mcrouter_exporter), they behave the same on merge (tagging with `branch-short_sha`) and pushing a tag (tagging with the version) as they do today, and I confirmed that I can start containers on both architectures from the built image.

The changes look more extensive than they are, to make this work there is a bit more setup and a switch to the `docker/build-push-action` action, which supports buildx+qemu.