### PR TITLE
Export fiber pool size stat

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ type Exporter struct {
 	devNullRequests               *prometheus.Desc
 	duration                      *prometheus.Desc
 	fibersAllocated               *prometheus.Desc
+	fibersPoolSize                *prometheus.Desc
 	proxyReqsProcessing           *prometheus.Desc
 	proxyReqsWaiting              *prometheus.Desc
 	requests                      *prometheus.Desc
@@ -192,6 +193,12 @@ func NewExporter(server string, timeout time.Duration, server_stats bool, logger
 		fibersAllocated: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "fibers_allocated"),
 			"Number of fibers (lightweight threads) created by mcrouter.",
+			nil,
+			nil,
+		),
+		fibersPoolSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "fibers_pool_size"),
+			"Number of fibers (lightweight threads) created by mcrouter that are currently in the free pool.",
 			nil,
 			nil,
 		),
@@ -519,6 +526,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		e.duration, prometheus.GaugeValue, e.parse(s, "duration_us"))
 	ch <- prometheus.MustNewConstMetric(
 		e.fibersAllocated, prometheus.GaugeValue, e.parse(s, "fibers_allocated"))
+	ch <- prometheus.MustNewConstMetric(
+		e.fibersPoolSize, prometheus.GaugeValue, e.parse(s, "fibers_pool_size"))
 	ch <- prometheus.MustNewConstMetric(
 		e.proxyReqsProcessing, prometheus.GaugeValue, e.parse(s, "proxy_reqs_processing"))
 	ch <- prometheus.MustNewConstMetric(

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func handleRequestStats(conn net.Conn) {
 	if err != nil {
 		fmt.Println("Error reading:", err.Error())
 	}
-	ret := []byte("STAT start_time 1\r\nSTAT version 0.0\r\nSTAT fibers_allocated 1\r\nSTAT commandargs --debug-fifo-root /var/lib/mcrouter/fifos --test-mode\r\nEND\r\n")
+	ret := []byte("STAT start_time 1\r\nSTAT version 0.0\r\nSTAT fibers_allocated 1\r\nSTAT fibers_pool_size 1\r\nSTAT commandargs --debug-fifo-root /var/lib/mcrouter/fifos --test-mode\r\nEND\r\n")
 	conn.Write(ret)
 	conn.Close()
 }
@@ -63,6 +63,7 @@ func TestStatsParsing(t *testing.T) {
 				expected["start_time"] = "1"
 				expected["version"] = "0.0"
 				expected["fibers_allocated"] = "1"
+				expected["fibers_pool_size"] = "1"
 				expected["commandargs"] = "--debug-fifo-root /var/lib/mcrouter/fifos --test-mode"
 				So(stats, ShouldResemble, expected)
 			})


### PR DESCRIPTION
The exporter currently exposes the total number of fibers allocated by mcrouter, but not the number of fibers that are in the free pool. This information can be useful to introspect the behavior of mcrouter's fiber manager, so expose this as a new gauge.